### PR TITLE
Improve efficiency for `Polygon`

### DIFF
--- a/src/priority_queue/mod.rs
+++ b/src/priority_queue/mod.rs
@@ -1,23 +1,24 @@
-#![allow(dead_code)]
 pub(crate) struct PriorityQueue<T: std::cmp::PartialOrd> {
     size: usize,
     content: Vec<T>,
 }
 
 impl<T: std::cmp::PartialOrd> PriorityQueue<T> {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             size: 0,
             content: Vec::new(),
         }
     }
 
+    /// Clears content and sets size to 0
+    #[allow(dead_code)]
     pub fn initialize(&mut self) {
         self.size = 0;
-        self.content = Vec::new();
+        self.content.clear();
     }
 
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.size == 0
     }
 
@@ -37,6 +38,7 @@ impl<T: std::cmp::PartialOrd> PriorityQueue<T> {
         self.size += 1;
     }
 
+    #[allow(dead_code)]
     pub fn peek(&self) -> Option<&T> {
         if self.is_empty() {
             return None;

--- a/src/util/coordinate/mod.rs
+++ b/src/util/coordinate/mod.rs
@@ -99,11 +99,13 @@ impl Coordinate {
     /// let c1 = geo_buf::Coordinate::new(3., 4.);
     /// assert_eq!(c1, (3., 4.).into());
     /// ```
-    pub fn new(x: f64, y: f64) -> Self {
+    #[inline]
+    #[must_use]
+    pub const fn new(x: f64, y: f64) -> Self {
         Self(x, y)
     }
 
-    /// Returns a tuple wihch has values of each component.
+    /// Returns a tuple which has values of each component.
     ///
     /// # Example
     ///
@@ -112,7 +114,8 @@ impl Coordinate {
     /// let t1 = c1.get_val();
     /// assert_eq!(t1, (3., 4.));
     /// ```
-    pub fn get_val(&self) -> (f64, f64) {
+    #[inline]
+    pub const fn get_val(&self) -> (f64, f64) {
         (self.0, self.1)
     }
 
@@ -172,8 +175,8 @@ impl Coordinate {
     /// + This operation is linear.
     /// + This operation is *not* commutative. (More precisely, it is anti-commutative.)
     /// + The sign of cross product indicates the orientation of **a** and **b**. If **a** lies before **b** in
-    /// the counter-clockwise (CCW for short) ordering, the sign of the result will be positive. If **a** lies after **b** in CCW ordering,
-    /// the sign will be negative. The result will be zero if two vectors are colinear. (I.e. lay on the same line.)
+    ///   the counter-clockwise (CCW for short) ordering, the sign of the result will be positive. If **a** lies after **b** in CCW ordering,
+    ///   the sign will be negative. The result will be zero if two vectors are co-linear. (I.e. lay on the same line.)
     ///
     pub fn outer_product(&self, rhs: &Self) -> f64 {
         self.0 * rhs.1 - self.1 * rhs.0

--- a/src/vertex_queue/mod.rs
+++ b/src/vertex_queue/mod.rs
@@ -41,9 +41,8 @@ pub(crate) struct Node {
     pub(crate) done: bool,
 }
 
-#[allow(dead_code)]
 impl Node {
-    fn new(index: usize, left: usize, right: usize) -> Self {
+    const fn new(index: usize, left: usize, right: usize) -> Self {
         Self {
             index: IndexType::RealIndex(index),
             left: IndexType::PointerIndex(left),
@@ -52,11 +51,13 @@ impl Node {
         }
     }
 
-    pub(crate) fn lv(&self) -> IndexType {
+    #[allow(dead_code)]
+    pub(crate) const fn lv(&self) -> IndexType {
         self.left
     }
 
-    pub(crate) fn rv(&self) -> IndexType {
+    #[allow(dead_code)]
+    pub(crate) const fn rv(&self) -> IndexType {
         self.right
     }
 }
@@ -139,32 +140,32 @@ impl VertexQueue {
         panic!("Expected parameter \"cv\" as IndexType::RealIndex")
     }
 
+    /// Get the left value of a `Node` at current value(cv)'s index
     pub(crate) fn lv(&self, cv: IndexType) -> IndexType {
         if let IndexType::PointerIndex(cv) = cv {
             return self.content[cv].left;
         }
         panic!("Expected parameter \"cv\" as IndexType::PointerIndex");
-    /// Get the left value of a `Node` at cv's index
     }
 
+    /// Get the right value of a `Node` at current value(cv)'s index
     pub(crate) fn rv(&self, cv: IndexType) -> IndexType {
         if let IndexType::PointerIndex(cv) = cv {
             return self.content[cv].right;
         }
         panic!("Expected parameter \"cv\" as IndexType::PointerIndex");
-    /// Get the right value of a `Node` at cv's index
     }
 
+    #[allow(dead_code)]
     pub(crate) fn llv(&self, cv: IndexType) -> IndexType {
         let cv = self.lv(cv);
         self.lv(cv)
-    #[allow(dead_code)]
     }
 
+    #[allow(dead_code)]
     pub(crate) fn rrv(&self, cv: IndexType) -> IndexType {
         let cv = self.rv(cv);
         self.rv(cv)
-    #[allow(dead_code)]
     }
 
     pub(crate) fn remove(&mut self, cv: IndexType) -> IndexType {

--- a/src/vertex_queue/mod.rs
+++ b/src/vertex_queue/mod.rs
@@ -77,7 +77,31 @@ impl VertexQueue {
     }
 
     pub(crate) fn initialize_from_polygon(&mut self, p: &Polygon) {
-        self.initialize_from_polygon_vector(&vec![p.clone()])
+        let offset = self.content.len();
+        let len = p.exterior().0.len() - 1;
+
+        self.start_vertex.push(offset);
+        for i in 0..len {
+            let new_node = Node::new(
+                i + offset,
+                (i + len - 1) % len + offset,
+                (i + 1) % len + offset,
+            );
+            self.content.push(new_node);
+        }
+        for i in 0..p.interiors().len() {
+            let offset = self.content.len();
+            let len = p.interiors()[i].0.len() - 1;
+            self.start_vertex.push(offset);
+            for j in 0..len {
+                let new_node = Node::new(
+                    j + offset,
+                    (j + len - 1) % len + offset,
+                    (j + 1) % len + offset,
+                );
+                self.content.push(new_node);
+            }
+        }
     }
 
     pub(crate) fn initialize_from_polygon_vector(&mut self, pv: &Vec<Polygon>) {

--- a/src/vertex_queue/mod.rs
+++ b/src/vertex_queue/mod.rs
@@ -67,9 +67,8 @@ pub(crate) struct VertexQueue {
     pub(crate) start_vertex: Vec<usize>,
 }
 
-#[allow(dead_code)]
 impl VertexQueue {
-    pub(crate) fn new() -> Self {
+    pub(crate) const fn new() -> Self {
         Self {
             content: Vec::new(),
             start_vertex: Vec::new(),
@@ -145,6 +144,7 @@ impl VertexQueue {
             return self.content[cv].left;
         }
         panic!("Expected parameter \"cv\" as IndexType::PointerIndex");
+    /// Get the left value of a `Node` at cv's index
     }
 
     pub(crate) fn rv(&self, cv: IndexType) -> IndexType {
@@ -152,16 +152,19 @@ impl VertexQueue {
             return self.content[cv].right;
         }
         panic!("Expected parameter \"cv\" as IndexType::PointerIndex");
+    /// Get the right value of a `Node` at cv's index
     }
 
     pub(crate) fn llv(&self, cv: IndexType) -> IndexType {
         let cv = self.lv(cv);
         self.lv(cv)
+    #[allow(dead_code)]
     }
 
     pub(crate) fn rrv(&self, cv: IndexType) -> IndexType {
         let cv = self.rv(cv);
         self.rv(cv)
+    #[allow(dead_code)]
     }
 
     pub(crate) fn remove(&mut self, cv: IndexType) -> IndexType {
@@ -235,7 +238,7 @@ impl VertexQueue {
             while cur != self.start_vertex[sv_idx] {
                 if visit[cur] {
                     panic!(
-                        "Something Worng in cleanup phase: cur {} from {}, sv {:?}",
+                        "Something Wrong in cleanup phase: cur {} from {}, sv {:?}",
                         cur, sv_idx, self.start_vertex
                     );
                 }


### PR DESCRIPTION
This patch simplifies the code while removing the need to allocate a new `MultiPolygon` for `Polygon` uses.